### PR TITLE
speed up Meta instantiation

### DIFF
--- a/packages/ember-metal/lib/events.js
+++ b/packages/ember-metal/lib/events.js
@@ -206,7 +206,7 @@ export function sendEvent(obj, eventName, params, actions) {
     actions = meta && meta.matchingListeners(eventName);
   }
 
-  if (!actions) { return; }
+  if (!actions || actions.length === 0) { return; }
 
   for (var i = actions.length - 3; i >= 0; i -= 3) { // looping in reverse for once listeners
     var target = actions[i];

--- a/packages/ember-metal/lib/meta.js
+++ b/packages/ember-metal/lib/meta.js
@@ -44,12 +44,16 @@ let members = {
 };
 
 let memberNames = Object.keys(members);
-let memberProperties = memberNames.map(memberProperty);
 
 function Meta(obj, parentMeta) {
-  // preallocate a slot for each member
-  memberProperties.forEach(prop => this[prop] = undefined);
-
+  this.cache = undefined;
+  this.watching = undefined;
+  this.mixins = undefined;
+  this.bindings = undefined;
+  this.values = undefined;
+  this.deps = undefined;
+  this.chainWatchers = undefined;
+  this.chains = undefined;
   // used only internally
   this.source = obj;
 

--- a/packages/ember-views/lib/views/component.js
+++ b/packages/ember-views/lib/views/component.js
@@ -171,7 +171,7 @@ var Component = View.extend(TargetActionSupport, ComponentTemplateDeprecation, {
 
   _template: computed('templateName', {
     get() {
-      if (get(this, '_deprecatedFlagForBlockProvided')) {
+      if (this._deprecatedFlagForBlockProvided) {
         return true;
       }
       var templateName = get(this, 'templateName');


### PR DESCRIPTION
6ms -> noise

turns out there is no 0 cost abstraction in JS yet...

![screen shot 2015-08-04 at 2 37 37 pm](https://cloud.githubusercontent.com/assets/1377/9073470/6893c976-3ab6-11e5-9a39-bbc90fcc3374.png)

![screen shot 2015-08-04 at 2 33 58 pm](https://cloud.githubusercontent.com/assets/1377/9073472/6a6ef39c-3ab6-11e5-9b54-2463ae44dc2c.png)

this is more or less the result after several independent runs.

This also seems to have pulled down GC cost, I suspect that context perserved by the `forEach` for `_this` was largely to blame for the later. With a for loop the perf was midway. So combination of both yielded a good win here. My test case over-all improved nicely, from always ~1050ms to always mid 950ms...
